### PR TITLE
(#6) support adding chain issuer data when issuer is in vault

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
Previously we could only sign direct authorized JWTs using vault but when the issuer is created in vault and we wish to delegate issuing clients we need to be able to get the issuer data signed by vault, which is now possible.

Signed-off-by: R.I.Pienaar <rip@devco.net>