### PR TITLE
(#16) Updated reliance on MD5 to use sha256 if FIPS is enabled

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: ["1.20", "1.21"]
+        go: ["1.24", "1.25"]
 
     runs-on: ubuntu-latest
     steps:

--- a/client_id.go
+++ b/client_id.go
@@ -6,7 +6,9 @@ package tokens
 
 import (
 	"crypto/ed25519"
+	"crypto/fips140"
 	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -92,7 +94,13 @@ var (
 
 // UniqueID returns the caller id and unique id used to generate private inboxes
 func (c *ClientIDClaims) UniqueID() (id string, uid string) {
-	return c.CallerID, fmt.Sprintf("%x", md5.Sum([]byte(c.CallerID)))
+	var hash any
+	if fips140.Enabled() {
+		hash = sha256.Sum256([]byte(c.CallerID))
+	} else {
+		hash = md5.Sum([]byte(c.CallerID))
+	}
+	return c.CallerID, fmt.Sprintf("%x", hash)
 }
 
 // NewClientIDClaims generates new ClientIDClaims

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/choria-io/tokens
 
-go 1.20
+go 1.24.0
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOW
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/server.go
+++ b/server.go
@@ -63,7 +63,7 @@ func (c *ServerClaims) UniqueID() (id string, uid string) {
 	if fips140.Enabled() {
 		hash = sha256.Sum256([]byte(c.ChoriaIdentity))
 	} else {
-		md5.Sum([]byte(c.ChoriaIdentity))
+		hash = md5.Sum([]byte(c.ChoriaIdentity))
 	}
 	return c.ChoriaIdentity, fmt.Sprintf("%x", hash)
 }

--- a/server.go
+++ b/server.go
@@ -7,7 +7,9 @@ package tokens
 import (
 	"bytes"
 	"crypto/ed25519"
+	"crypto/fips140"
 	"crypto/md5"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -57,7 +59,13 @@ var (
 
 // UniqueID returns the identity and unique id used to generate private inboxes
 func (c *ServerClaims) UniqueID() (id string, uid string) {
-	return c.ChoriaIdentity, fmt.Sprintf("%x", md5.Sum([]byte(c.ChoriaIdentity)))
+	var hash any
+	if fips140.Enabled() {
+		hash = sha256.Sum256([]byte(c.ChoriaIdentity))
+	} else {
+		md5.Sum([]byte(c.ChoriaIdentity))
+	}
+	return c.ChoriaIdentity, fmt.Sprintf("%x", hash)
 }
 
 // IsMatchingPublicKey checks that the stored public key matches the supplied one


### PR DESCRIPTION
Added a check to see if the binary is FIPS compliant and if so, will use sha256 and if it isn't, it'll use MD5